### PR TITLE
feat(5.0): post rewrite & rollback — preview + apply (5.1–5.6)

### DIFF
--- a/src/lib/db/repository.ts
+++ b/src/lib/db/repository.ts
@@ -87,3 +87,28 @@ export async function upsertConfig(key: string, value: any) {
   if (error) throw error;
   return data;
 }
+
+// Post rewrites audit table helpers
+export type PostRewriteRecord = {
+  id?: number;
+  post_id: number;
+  original_url: string;
+  optimized_url: string;
+  field: string; // 'content' or 'featured_media' etc
+  created_at?: string | null;
+  metadata?: Record<string, unknown> | null;
+};
+
+export async function insertPostRewrite(row: Omit<PostRewriteRecord, 'id' | 'created_at'>) {
+  const sb = getSupabaseClient();
+  const { data, error } = await sb.from('post_rewrites').insert(row).select();
+  if (error) throw error;
+  return data as PostRewriteRecord[];
+}
+
+export async function getPostRewritesForPost(postId: number) {
+  const sb = getSupabaseClient();
+  const { data, error } = await sb.from('post_rewrites').select('*').eq('post_id', postId);
+  if (error) throw error;
+  return data as PostRewriteRecord[];
+}

--- a/src/lib/rollback/README_5_1.md
+++ b/src/lib/rollback/README_5_1.md
@@ -1,0 +1,2 @@
+# Task 5.1: Post Rewrite - Replacement placeholder
+This file is a small test placeholder for implementing content replacement (task 5.1).

--- a/src/lib/rollback/manager.ts
+++ b/src/lib/rollback/manager.ts
@@ -1,0 +1,82 @@
+import { previewRewrites } from './preview';
+import { rewriteHtmlImageUrls, Replacement } from './replace';
+import { restoreHtmlFromMapping } from './restore';
+import { createWpClient } from '../wordpress/client';
+import { insertPostRewrite } from '../db/repository';
+
+type PostRecord = { id: number; content: string; featured_media?: number | null };
+
+export async function previewAndPlan(posts: PostRecord[], mapping: Replacement[]) {
+  // returns preview entries per post
+  return previewRewrites(posts.map((p) => ({ id: p.id, html: p.content })), mapping);
+}
+
+export async function applyRewrites(posts: PostRecord[], mapping: Replacement[], opts?: { updateFeatured?: boolean }) {
+  const wp = createWpClient();
+  const results: Array<{ postId: number; applied: number; errors?: string[] }> = [];
+
+  for (const p of posts) {
+    const { html: rewrittenHtml, replacements } = rewriteHtmlImageUrls(p.content, mapping);
+    let applied = 0;
+    const errors: string[] = [];
+
+    if (replacements.length > 0) {
+      // patch post content
+      try {
+        // wp client doesn't expose post/put wrapper here — use raw fetch via client.get path but it's okay to call fetch directly
+        const cfg = (await import('../../config')).loadConfig();
+        const base = cfg.wpBaseUrl.replace(/\/$/, '');
+        const url = new URL(`/wp/v2/posts/${p.id}`, base).toString();
+        const headers: any = { 'Content-Type': 'application/json' };
+        if (cfg.wpAppUser && cfg.wpAppPassword) {
+          const token = Buffer.from(`${cfg.wpAppUser}:${cfg.wpAppPassword}`).toString('base64');
+          headers.Authorization = `Basic ${token}`;
+        }
+
+        const resp = await fetch(url, { method: 'POST', headers, body: JSON.stringify({ content: rewrittenHtml }) });
+        if (!resp.ok) {
+          const body = await resp.text().catch(() => '');
+          errors.push(`post update failed: ${resp.status} ${body}`);
+        } else {
+          applied += replacements.length;
+        }
+      } catch (err: any) {
+        errors.push(String(err?.message ?? err));
+      }
+
+      // store audit records
+      try {
+        for (const r of replacements) {
+          await insertPostRewrite({ post_id: p.id, original_url: r.originalUrl, optimized_url: r.optimizedUrl, field: r.originalSrcAttr ?? 'content', metadata: null });
+        }
+      } catch (err: any) {
+        errors.push(`db insert failed: ${String(err?.message ?? err)}`);
+      }
+    }
+
+    // optionally update featured_media if mapping includes the featured_media URL
+    if (opts?.updateFeatured && p.featured_media) {
+      // fetch media object and compare source_url
+      try {
+        const mediaRes = await wp.get(`/wp/v2/media/${p.featured_media}`);
+        if (mediaRes && mediaRes.data && mediaRes.data.source_url) {
+          const src = mediaRes.data.source_url as string;
+          const found = mapping.find((m) => m.originalUrl === src);
+          if (found) {
+            // upload/replace: in WP, featured_media is an ID pointing to an attachment; to change we'd need to create a media item or find existing one.
+            // For now, if the optimized URL is already present as an attachment in WP, we'd need to find its ID — this implementation logs intent and records an audit.
+            // TODO: create or locate attachment for optimizedUrl and set featured_media to its ID.
+            // Record an audit entry for featured_media field so operator can review.
+            await insertPostRewrite({ post_id: p.id, original_url: src, optimized_url: found.optimizedUrl, field: 'featured_media', metadata: null });
+          }
+        }
+      } catch (err: any) {
+        errors.push(`featured_media check failed: ${String(err?.message ?? err)}`);
+      }
+    }
+
+    results.push({ postId: p.id, applied, errors: errors.length ? errors : undefined });
+  }
+
+  return results;
+}

--- a/src/lib/rollback/preview.ts
+++ b/src/lib/rollback/preview.ts
@@ -1,0 +1,19 @@
+import { rewriteHtmlImageUrls, Replacement } from './replace';
+
+export type PreviewEntry = {
+  postId?: number | string;
+  originalHtml: string;
+  rewrittenHtml: string;
+  replacements: Replacement[];
+};
+
+/**
+ * Generate a preview for a set of posts (html strings) given a mapping of original->optimized URLs.
+ * Returns an array of preview entries with diffs (rewrittenHtml and list of replacements)
+ */
+export function previewRewrites(posts: { id?: number | string; html: string }[], mapping: Replacement[]) {
+  return posts.map((p) => {
+    const { html: rewrittenHtml, replacements } = rewriteHtmlImageUrls(p.html, mapping);
+    return { postId: p.id, originalHtml: p.html, rewrittenHtml, replacements } as PreviewEntry;
+  });
+}

--- a/src/lib/rollback/replace.ts
+++ b/src/lib/rollback/replace.ts
@@ -1,0 +1,50 @@
+import * as cheerio from 'cheerio';
+
+export type Replacement = {
+  originalUrl: string;
+  optimizedUrl: string;
+  originalSrcAttr?: string; // 'src' or 'srcset' primary attribute used
+};
+
+/**
+ * Perform a DOM-safe replacement of image URLs in an HTML string.
+ * - Replaces exact matches in `src` attributes
+ * - Rewrites individual entries in `srcset` lists when the candidate URL matches
+ * - Returns the rewritten HTML and a list of replacements performed
+ */
+export function rewriteHtmlImageUrls(html: string, mapping: Replacement[]) {
+  // cheerio types don't include the decodeEntities option in some versions — cast to any
+  const $ = cheerio.load(html, ({ decodeEntities: false } as any));
+  const replacements: Replacement[] = [];
+
+  const mapByOriginal = new Map(mapping.map((m) => [m.originalUrl, m]));
+
+  $('img').each((_, el) => {
+    const $el = $(el);
+    const src = $el.attr('src');
+    if (src && mapByOriginal.has(src)) {
+      const m = mapByOriginal.get(src)!;
+      $el.attr('src', m.optimizedUrl);
+      replacements.push({ ...m, originalSrcAttr: 'src' });
+    }
+
+    const srcset = $el.attr('srcset');
+    if (srcset) {
+      // split on commas but be forgiving about whitespace
+      const parts = srcset.split(',').map((s) => s.trim()).filter(Boolean);
+      const newParts = parts.map((part) => {
+        // each part: "<url> <descriptor>" or just "<url>"
+        const [url, descriptor] = part.split(/\s+/, 2);
+        if (mapByOriginal.has(url)) {
+          const m = mapByOriginal.get(url)!;
+          replacements.push({ ...m, originalSrcAttr: 'srcset' });
+          return descriptor ? `${m.optimizedUrl} ${descriptor}` : m.optimizedUrl;
+        }
+        return part;
+      });
+      $el.attr('srcset', newParts.join(', '));
+    }
+  });
+
+  return { html: $.html(), replacements };
+}

--- a/src/lib/rollback/restore.ts
+++ b/src/lib/rollback/restore.ts
@@ -1,0 +1,36 @@
+import * as cheerio from 'cheerio';
+import type { Replacement } from './replace';
+
+/**
+ * Reverts optimized URLs back to their original URLs in an HTML string.
+ * This expects mapping entries with originalUrl and optimizedUrl.
+ */
+export function restoreHtmlFromMapping(html: string, mapping: Replacement[]) {
+  const $ = cheerio.load(html, ({ decodeEntities: false } as any));
+  const mapByOptimized = new Map(mapping.map((m) => [m.optimizedUrl, m]));
+
+  $('img').each((_, el) => {
+    const $el = $(el);
+    const src = $el.attr('src');
+    if (src && mapByOptimized.has(src)) {
+      const m = mapByOptimized.get(src)!;
+      $el.attr('src', m.originalUrl);
+    }
+
+    const srcset = $el.attr('srcset');
+    if (srcset) {
+      const parts = srcset.split(',').map((s) => s.trim()).filter(Boolean);
+      const newParts = parts.map((part) => {
+        const [url, descriptor] = part.split(/\s+/, 2);
+        if (mapByOptimized.has(url)) {
+          const m = mapByOptimized.get(url)!;
+          return descriptor ? `${m.originalUrl} ${descriptor}` : m.originalUrl;
+        }
+        return part;
+      });
+      $el.attr('srcset', newParts.join(', '));
+    }
+  });
+
+  return $.html();
+}

--- a/tasks/WORK_5_0_START.md
+++ b/tasks/WORK_5_0_START.md
@@ -1,0 +1,2 @@
+Start work for 5.0
+Timestamp: Mon 06 Oct 2025 05:44:33 PM UTC

--- a/tests/unit/rollback/manager.test.ts
+++ b/tests/unit/rollback/manager.test.ts
@@ -1,0 +1,39 @@
+import { previewAndPlan, applyRewrites } from '../../../src/lib/rollback/manager';
+import * as repo from '../../../src/lib/db/repository';
+
+// Mock fetch globally for post update
+const globalAny: any = global;
+
+describe('rollback manager', () => {
+  const original = 'https://cdn.example.com/uploads/pic.jpg';
+  const optimized = 'https://cdn.example.com/uploads/pic__opt.webp';
+  const post = { id: 11, content: `<p><img src="${original}" /></p>`, featured_media: null };
+  const mapping = [{ originalUrl: original, optimizedUrl: optimized }];
+
+  beforeAll(() => {
+    // mock insertPostRewrite
+    jest.spyOn(repo, 'insertPostRewrite').mockImplementation(async (row: any) => [ { id: 1, ...row } ] as any);
+  });
+
+  afterAll(() => {
+    jest.restoreAllMocks();
+    delete globalAny.fetch;
+  });
+
+  test('previewAndPlan returns rewritten html', async () => {
+    const previews = await previewAndPlan([post], mapping);
+    expect(previews.length).toBe(1);
+    expect(previews[0].replacements.length).toBeGreaterThan(0);
+  });
+
+  test('applyRewrites posts updated content and records audit', async () => {
+    // mock fetch for WP post update
+    globalAny.fetch = jest.fn().mockResolvedValue({ ok: true, json: async () => ({ id: post.id }) });
+
+    const res = await applyRewrites([post], mapping, { updateFeatured: false });
+    expect(res.length).toBe(1);
+    expect(res[0].applied).toBeGreaterThan(0);
+    // ensure DB audit inserted
+    expect(repo.insertPostRewrite).toHaveBeenCalled();
+  });
+});

--- a/tests/unit/rollback/replace.test.ts
+++ b/tests/unit/rollback/replace.test.ts
@@ -1,0 +1,53 @@
+import { rewriteHtmlImageUrls } from '../../../src/lib/rollback/replace';
+import { previewRewrites } from '../../../src/lib/rollback/preview';
+import { restoreHtmlFromMapping } from '../../../src/lib/rollback/restore';
+
+describe('rollback rewrite/preview/restore', () => {
+  const original1 = 'https://cdn.example.com/uploads/2020/01/pic1.jpg';
+  const optimized1 = 'https://cdn.example.com/uploads/2020/01/pic1__opt.webp';
+  const original2 = 'https://cdn.example.com/uploads/2020/01/icon.svg';
+  const optimized2 = 'https://cdn.example.com/uploads/2020/01/icon__opt.webp';
+
+  const html = `
+    <p>Intro</p>
+    <img src="${original1}" alt="photo" />
+    <img src="${original2}" srcset="${original2} 1x, ${original1} 2x" />
+  `;
+
+  test('rewriteHtmlImageUrls replaces src and entries in srcset', () => {
+    const mapping = [
+      { originalUrl: original1, optimizedUrl: optimized1 },
+      { originalUrl: original2, optimizedUrl: optimized2 },
+    ];
+
+    const res = rewriteHtmlImageUrls(html, mapping);
+  // There are four attribute occurrences replaced: src for original1, src for original2,
+  // and two srcset entries (original2 1x, original1 2x)
+  expect(res.replacements.length).toBe(4);
+    expect(res.html).toContain(optimized1);
+    expect(res.html).toContain(optimized2);
+    // srcset should contain optimized1 as 2x
+    expect(res.html).toMatch(new RegExp(`${optimized1} 2x`));
+  });
+
+  test('previewRewrites returns entries with rewrittenHtml', () => {
+    const mapping = [{ originalUrl: original1, optimizedUrl: optimized1 }];
+    const posts = [{ id: 42, html }];
+    const previews = previewRewrites(posts, mapping);
+    expect(previews.length).toBe(1);
+    expect(previews[0].replacements.length).toBeGreaterThan(0);
+  });
+
+  test('restoreHtmlFromMapping reverts optimized urls back to original', () => {
+    const mapping = [
+      { originalUrl: original1, optimizedUrl: optimized1 },
+      { originalUrl: original2, optimizedUrl: optimized2 },
+    ];
+    const { html: rewritten } = rewriteHtmlImageUrls(html, mapping);
+    const restored = restoreHtmlFromMapping(rewritten, mapping);
+    expect(restored).toContain(original1);
+    expect(restored).toContain(original2);
+    // ensure optimized urls are not present
+    expect(restored).not.toContain(optimized1);
+  });
+});


### PR DESCRIPTION
Implements DOM-safe content rewrite for img src/srcset, preview and restore utilities, rollback manager orchestration, and post_rewrites audit logging. Partial featured_media handling (audit-only). Includes unit tests.\n\nDo not merge until reviewed.