### PR TITLE
Feat/dashboard 6.1 supabase auth 2

### DIFF
--- a/artifacts/dry-run.json
+++ b/artifacts/dry-run.json
@@ -1,7 +1,0 @@
-{
-  "total_images": 0,
-  "total_bytes": 0,
-  "estimated_webp_bytes": 0,
-  "estimated_savings": 0,
-  "per_image": []
-}

--- a/dashboard/app/page.tsx
+++ b/dashboard/app/page.tsx
@@ -1,14 +1,41 @@
 "use client"
-import React from 'react'
+import React, { useState } from 'react'
 import ProgressCards from '../components/ProgressCards'
 import dynamic from 'next/dynamic'
+import { triggerDryRun, triggerOptimize, triggerRollback } from '../lib/api'
 
 const ImageTable = dynamic(() => import('../components/ImageTable'), { ssr: false });
 
 export default function Page() {
+  const [opMessage, setOpMessage] = useState<string | null>(null)
+  const [busy, setBusy] = useState(false)
+
+  async function doOp(fn: () => Promise<any>, label: string) {
+    if (!confirm(`Are you sure you want to ${label}?`)) return
+    setBusy(true)
+    setOpMessage(null)
+    try {
+      const res = await fn()
+      setOpMessage(`${label} queued: ${res?.jobId ?? 'ok'}`)
+    } catch (e: any) {
+      setOpMessage(`${label} failed: ${String(e?.message || e)}`)
+    } finally {
+      setBusy(false)
+    }
+  }
+
   return (
     <div>
       <ProgressCards />
+      <section>
+        <h2>Operations</h2>
+        <div style={{ display: 'flex', gap: 8, marginBottom: 12 }}>
+          <button disabled={busy} onClick={() => doOp(() => triggerDryRun(), 'Trigger dry-run')}>Trigger dry-run</button>
+          <button disabled={busy} onClick={() => doOp(() => triggerOptimize(), 'Start optimize')}>Start optimize</button>
+          <button disabled={busy} onClick={() => doOp(() => triggerRollback(), 'Start rollback')}>Start rollback</button>
+        </div>
+        {opMessage && <div><strong>{opMessage}</strong></div>}
+      </section>
       <section>
         <h2>Recent Activity</h2>
         <p>Placeholder for recent runs and summaries.</p>

--- a/dashboard/app/settings/page.tsx
+++ b/dashboard/app/settings/page.tsx
@@ -1,10 +1,97 @@
-import React from 'react';
+"use client"
+
+import React, { useEffect, useState } from 'react'
+
+type Settings = {
+  enableAvif?: boolean
+  qualityProfile?: string
+  concurrency?: number
+  scheduleStart?: string
+  scheduleEnd?: string
+}
 
 export default function SettingsPage() {
+  const [settings, setSettings] = useState<Settings>({})
+  const [loading, setLoading] = useState(true)
+  const [saving, setSaving] = useState(false)
+  const [message, setMessage] = useState<string | null>(null)
+
+  useEffect(() => {
+    let mounted = true
+    async function load() {
+      setLoading(true)
+      try {
+        const res = await fetch('/dashboard/api/settings')
+        if (!res.ok) throw new Error('fetch failed')
+        const body = await res.json()
+        if (!mounted) return
+        setSettings(body.config || {})
+      } catch (e) {
+        // ignore
+      } finally {
+        if (mounted) setLoading(false)
+      }
+    }
+    load()
+    return () => { mounted = false }
+  }, [])
+
+  async function save() {
+    setSaving(true)
+    setMessage(null)
+    try {
+      const res = await fetch('/dashboard/api/settings', {
+        method: 'POST',
+        headers: { 'Content-Type': 'application/json' },
+        body: JSON.stringify(settings),
+      })
+      if (!res.ok) throw new Error('save failed')
+      setMessage('Saved')
+    } catch (e: any) {
+      setMessage(String(e?.message || e))
+    } finally {
+      setSaving(false)
+    }
+  }
+
+  if (loading) return <div>Loading settings…</div>
+
   return (
     <div>
       <h2>Settings</h2>
-      <p>Toggle AVIF, scheduling, and concurrency caps will be available here.</p>
+      <label>
+        <input type="checkbox" checked={!!settings.enableAvif} onChange={(e) => setSettings({ ...settings, enableAvif: e.target.checked })} /> Enable AVIF generation
+      </label>
+      <div style={{ marginTop: 8 }}>
+        <label>
+          Quality profile:
+          <select value={settings.qualityProfile || 'photographic'} onChange={(e) => setSettings({ ...settings, qualityProfile: e.target.value })} style={{ marginLeft: 6 }}>
+            <option value="photographic">photographic</option>
+            <option value="graphics">graphics</option>
+          </select>
+        </label>
+      </div>
+      <div style={{ marginTop: 8 }}>
+        <label>
+          Concurrency:
+          <input type="number" value={settings.concurrency ?? 3} onChange={(e) => setSettings({ ...settings, concurrency: Number(e.target.value) })} style={{ marginLeft: 6, width: 80 }} />
+        </label>
+      </div>
+      <div style={{ marginTop: 8 }}>
+        <label>
+          Schedule start:
+          <input type="time" value={settings.scheduleStart || ''} onChange={(e) => setSettings({ ...settings, scheduleStart: e.target.value })} style={{ marginLeft: 6 }} />
+        </label>
+        <label style={{ marginLeft: 12 }}>
+          Schedule end:
+          <input type="time" value={settings.scheduleEnd || ''} onChange={(e) => setSettings({ ...settings, scheduleEnd: e.target.value })} style={{ marginLeft: 6 }} />
+        </label>
+      </div>
+
+      <div style={{ marginTop: 12 }}>
+        <button onClick={save} disabled={saving}>{saving ? 'Saving…' : 'Save'}</button>
+        {message && <span style={{ marginLeft: 8 }}>{message}</span>}
+      </div>
     </div>
-  );
+  )
 }

--- a/dashboard/lib/api.ts
+++ b/dashboard/lib/api.ts
@@ -1,11 +1,21 @@
+import { apiFetch } from './fetchClient'
+
 export async function fetchSummary() {
-  const res = await fetch('/api/summary');
-  if (!res.ok) throw new Error('fetchSummary failed');
-  return res.json();
+  return apiFetch('/dashboard/api/summary')
 }
 
 export async function fetchImages(page = 1) {
-  const res = await fetch(`/api/images?page=${page}`);
-  if (!res.ok) throw new Error('fetchImages failed');
-  return res.json();
+  return apiFetch(`/dashboard/api/images?page=${page}`)
+}
+
+export async function triggerDryRun() {
+  return apiFetch('/dashboard/api/dry-run', { method: 'POST' })
+}
+
+export async function triggerOptimize() {
+  return apiFetch('/dashboard/api/optimize', { method: 'POST' })
+}
+
+export async function triggerRollback() {
+  return apiFetch('/dashboard/api/rollback', { method: 'POST' })
 }

--- a/dashboard/lib/fetchClient.ts
+++ b/dashboard/lib/fetchClient.ts
@@ -1,0 +1,38 @@
+export class ApiError extends Error {
+  status: number
+  body: any
+  constructor(message: string, status = 500, body: any = null) {
+    super(message)
+    this.status = status
+    this.body = body
+  }
+}
+
+export async function apiFetch(path: string, opts: RequestInit = {}, timeoutMs = 10000) {
+  const url = path.startsWith('/') ? path : `/dashboard/api/${path}`
+  const controller = new AbortController()
+  const id = setTimeout(() => controller.abort(), timeoutMs)
+  try {
+    const fetchPromise = fetch(url, { ...opts, signal: controller.signal })
+    const abortPromise = new Promise((_, reject) => {
+      controller.signal.addEventListener('abort', () => reject(new ApiError('Request timeout', 408, null)))
+    })
+    const res: any = await Promise.race([fetchPromise, abortPromise])
+    clearTimeout(id)
+    if (!res.ok) {
+      let body = null
+      try { body = await (typeof res.json === 'function' ? res.json() : res.text()) } catch (_) { body = await (res.text?.() ?? null) }
+      throw new ApiError(`Request failed: ${res.statusText}`, res.status, body)
+    }
+    // Prefer json() when available (common in fetch mocks), otherwise fall back to text()
+    if (typeof res.json === 'function') return res.json()
+    if (typeof res.text === 'function') {
+      const txt = await res.text()
+      try { return JSON.parse(txt) } catch (_) { return txt }
+    }
+    return null
+  } catch (err: any) {
+    if (err instanceof ApiError) throw err
+    throw new ApiError(err?.message || String(err), 500, null)
+  }
+}

--- a/dashboard/pages/api/optimize.ts
+++ b/dashboard/pages/api/optimize.ts
@@ -1,0 +1,16 @@
+import type { NextApiRequest, NextApiResponse } from 'next'
+import { requireAdmin } from '../../lib/requireAdmin'
+import { enqueueJob } from '../../../src/lib/queue'
+
+export default async function handler(req: NextApiRequest, res: NextApiResponse) {
+  const guard = await requireAdmin(req as unknown as Request)
+  if (!guard.ok) return res.status(guard.status || 401).json({ error: guard.message })
+
+  try {
+    const { jobId } = await enqueueJob('optimize', { requestedBy: guard.user?.id ?? null })
+    return res.status(200).json({ ok: true, queued: true, jobId })
+  } catch (err: any) {
+    console.error('optimize api error', err?.message || err)
+    res.status(500).json({ error: String(err?.message || err) })
+  }
+}

--- a/dashboard/pages/api/rollback.ts
+++ b/dashboard/pages/api/rollback.ts
@@ -1,0 +1,16 @@
+import type { NextApiRequest, NextApiResponse } from 'next'
+import { requireAdmin } from '../../lib/requireAdmin'
+import { enqueueJob } from '../../../src/lib/queue'
+
+export default async function handler(req: NextApiRequest, res: NextApiResponse) {
+  const guard = await requireAdmin(req as unknown as Request)
+  if (!guard.ok) return res.status(guard.status || 401).json({ error: guard.message })
+
+  try {
+    const { jobId } = await enqueueJob('rollback', { requestedBy: guard.user?.id ?? null })
+    return res.status(200).json({ ok: true, queued: true, jobId })
+  } catch (err: any) {
+    console.error('rollback api error', err?.message || err)
+    res.status(500).json({ error: String(err?.message || err) })
+  }
+}

--- a/dashboard/pages/api/settings.ts
+++ b/dashboard/pages/api/settings.ts
@@ -1,0 +1,47 @@
+import type { NextApiRequest, NextApiResponse } from 'next'
+import { requireAdmin } from '../../lib/requireAdmin'
+import { upsertConfig } from '../../../src/lib/db/repository'
+import { z } from 'zod'
+
+const CONFIG_KEY = 'dashboard:settings'
+
+const SettingsSchema = z.object({
+  enableAvif: z.boolean().optional(),
+  qualityProfile: z.enum(['photographic', 'graphics']).optional(),
+  concurrency: z.number().int().min(1).max(64).optional(),
+  scheduleStart: z.string().regex(/^(?:[01]\d|2[0-3]):[0-5]\d$/).optional(),
+  scheduleEnd: z.string().regex(/^(?:[01]\d|2[0-3]):[0-5]\d$/).optional(),
+})
+
+export default async function handler(req: NextApiRequest, res: NextApiResponse) {
+  const guard = await requireAdmin(req as unknown as Request)
+  if (!guard.ok) return res.status(guard.status || 401).json({ error: guard.message })
+
+  try {
+    if (req.method === 'GET') {
+      // read via repository helper
+      try {
+        const gc = await (await import('../../../src/lib/db/repository')).getConfig(CONFIG_KEY)
+        return res.status(200).json({ config: gc || {} })
+      } catch (e) {
+        return res.status(200).json({ config: {} })
+      }
+    }
+
+    if (req.method === 'POST') {
+      const payload = req.body || {}
+      const parsed = SettingsSchema.safeParse(payload)
+      if (!parsed.success) {
+        return res.status(400).json({ error: 'validation', issues: parsed.error.format() })
+      }
+      await upsertConfig(CONFIG_KEY, parsed.data)
+      return res.status(200).json({ ok: true })
+    }
+
+    res.setHeader('Allow', 'GET,POST')
+    return res.status(405).end('Method Not Allowed')
+  } catch (err: any) {
+    console.error('settings api error', err?.message || err)
+    res.status(500).json({ error: String(err?.message || err) })
+  }
+}

--- a/src/lib/db/repository.ts
+++ b/src/lib/db/repository.ts
@@ -88,6 +88,16 @@ export async function upsertConfig(key: string, value: any) {
   return data;
 }
 
+export async function getConfig(key: string) {
+  const sb = getSupabaseClient();
+  const { data, error } = await sb.from('config').select('value').eq('key', key).single();
+  if (error) {
+    // return null if not found or other non-fatal error
+    throw error;
+  }
+  return data?.value ?? null;
+}
+
 // Post rewrites audit table helpers
 export type PostRewriteRecord = {
   id?: number;

--- a/src/lib/queue/index.ts
+++ b/src/lib/queue/index.ts
@@ -1,0 +1,19 @@
+/**
+ * Minimal in-memory enqueue helper for dashboard operations.
+ * This is intentionally simple: it records jobs in a local array and returns a jobId.
+ * In production this should be replaced with a persistent queue or DB-backed job table.
+ */
+type Job = { id: string; type: string; payload?: any; createdAt: number; status: string };
+
+const JOBS: Job[] = [];
+
+export function enqueueJob(type: string, payload?: any) {
+  const jobId = `${type}-${Date.now()}-${Math.random().toString(36).slice(2, 8)}`;
+  const job: Job = { id: jobId, type, payload: payload ?? null, createdAt: Date.now(), status: 'queued' };
+  JOBS.push(job);
+  return Promise.resolve({ jobId, job });
+}
+
+export function listJobs() {
+  return JOBS.slice();
+}

--- a/tasks/tasks-0001-prd-media-refinery.md
+++ b/tasks/tasks-0001-prd-media-refinery.md
@@ -136,7 +136,7 @@ Generated from `0001-prd-media-refinery.md` (Expanded with detailed sub-tasks)
   - [x] 6.5 Add filter bar for author/date ranges and status selection
   - [x] 6.6 Create dry-run report page with summary stats, per-image breakdown, and export (CSV/JSON)
   - [x] 6.7 Build image detail page showing original vs optimized metadata and savings
-  - [ ] 6.8 Develop settings page for AVIF toggle, quality profiles, concurrency, and scheduling
+  - [x] 6.8 Develop settings page for AVIF toggle, quality profiles, concurrency, and scheduling
   - [ ] 6.9 Implement API client wrappers with error handling and normalization
   - [ ] 6.10 Add operation triggers (dry-run, optimize, rollback) with confirmation dialogs
   - [ ] 6.11 Integrate real-time updates via polling for progress indicators

--- a/tasks/tasks-0001-prd-media-refinery.md
+++ b/tasks/tasks-0001-prd-media-refinery.md
@@ -128,7 +128,6 @@ Generated from `0001-prd-media-refinery.md` (Expanded with detailed sub-tasks)
   - [x] 5.6 Tests for rewrite & rollback correctness
 
 - [ ] 6.0 Dashboard (Next.js) & API Integration
-  - [ ] 6.1 Implement Supabase authentication with session management
   - [x] 6.1 Implement Supabase authentication with session management
   - [x] 6.2 Create protected routes with role-based access (admin group)
   - [x] 6.3 Build main dashboard page with real-time progress cards (optimized/skipped/bytes saved counts)
@@ -139,7 +138,7 @@ Generated from `0001-prd-media-refinery.md` (Expanded with detailed sub-tasks)
   - [x] 6.8 Develop settings page for AVIF toggle, quality profiles, concurrency, and scheduling
   - [ ] 6.9 Implement API client wrappers with error handling and normalization
   - [ ] 6.10 Add operation triggers (dry-run, optimize, rollback) with confirmation dialogs
-  - [ ] 6.11 Integrate real-time updates via polling for progress indicators
+  - [x] 6.11 Integrate real-time updates via polling for progress indicators
   - [ ] 6.12 Implement charts for savings analytics and performance metrics
   - [ ] 6.13 Add bulk actions for image management (retry, reprocess)
   - [ ] 6.14 Create audit logs view for operation history

--- a/tests/artifacts/load-spot.json
+++ b/tests/artifacts/load-spot.json
@@ -1,18 +1,18 @@
 {
   "total": 200,
-  "success": 200,
-  "transient": 0,
+  "success": 199,
+  "transient": 1,
   "fatal": 0,
-  "avgLatency": 165.49651003000002,
-  "durationSec": 7.189424547000001,
-  "throughput": 27.818638152820714,
+  "avgLatency": 171.72461231999998,
+  "durationSec": 7.37945592,
+  "throughput": 27.102269078937734,
   "finalConcurrency": 5,
   "stats": {
     "total": 100,
-    "transient": 0,
+    "transient": 1,
     "fatal": 0,
-    "success": 100,
-    "transientRate": 0,
+    "success": 99,
+    "transientRate": 0.01,
     "fatalRate": 0
   }
 }

--- a/tests/artifacts/load-spot.json
+++ b/tests/artifacts/load-spot.json
@@ -1,18 +1,18 @@
 {
   "total": 200,
-  "success": 196,
-  "transient": 3,
-  "fatal": 1,
-  "avgLatency": 182.18647411,
-  "durationSec": 37.526960128,
-  "throughput": 5.329501758677596,
-  "finalConcurrency": 1,
+  "success": 200,
+  "transient": 0,
+  "fatal": 0,
+  "avgLatency": 165.49651003000002,
+  "durationSec": 7.189424547000001,
+  "throughput": 27.818638152820714,
+  "finalConcurrency": 5,
   "stats": {
     "total": 100,
-    "transient": 2,
+    "transient": 0,
     "fatal": 0,
-    "success": 98,
-    "transientRate": 0.02,
+    "success": 100,
+    "transientRate": 0,
     "fatalRate": 0
   }
 }

--- a/tests/integration/dashboard/settings.page.integration.test.tsx
+++ b/tests/integration/dashboard/settings.page.integration.test.tsx
@@ -1,0 +1,31 @@
+/**
+ * @jest-environment jsdom
+ */
+import React from 'react'
+import '@testing-library/jest-dom'
+import { render, screen, waitFor, fireEvent } from '@testing-library/react'
+import SettingsPage from '../../../dashboard/app/settings/page'
+
+describe('Settings page integration', () => {
+  beforeAll(() => {
+  const getResp = { config: { enableAvif: false, qualityProfile: 'photographic', concurrency: 3, scheduleStart: '09:00', scheduleEnd: '17:00' } };
+  (global as any).fetch = jest.fn((url: string, opts?: any) => {
+      if (!opts || opts.method === 'GET') return Promise.resolve({ ok: true, json: async () => getResp })
+      // POST
+      return Promise.resolve({ ok: true, json: async () => ({ ok: true }) })
+    })
+  })
+
+  afterAll(() => {
+    delete (global as any).fetch
+  })
+
+  test('loads settings and saves', async () => {
+    render(<SettingsPage />)
+    await waitFor(() => expect(screen.getByText(/Enable AVIF generation/i)).toBeInTheDocument())
+    const save = screen.getByText(/Save/i)
+    fireEvent.click(save)
+    await waitFor(() => expect((global as any).fetch).toHaveBeenCalled())
+    expect(screen.getByText(/Saved/i)).toBeInTheDocument()
+  })
+})

--- a/tests/unit/dashboard/api.test.ts
+++ b/tests/unit/dashboard/api.test.ts
@@ -5,8 +5,8 @@ describe('dashboard api wrapper', () => {
 
   beforeAll(() => {
     globalAny.fetch = jest.fn((url: string) => {
-      if (url.startsWith('/api/summary')) return Promise.resolve({ ok: true, json: async () => ({ optimized: 1 }) });
-      if (url.startsWith('/api/images')) return Promise.resolve({ ok: true, json: async () => ({ images: [] }) });
+      if (url.startsWith('/dashboard/api/summary')) return Promise.resolve({ ok: true, json: async () => ({ optimized: 1 }) });
+      if (url.startsWith('/dashboard/api/images')) return Promise.resolve({ ok: true, json: async () => ({ images: [] }) });
       return Promise.resolve({ ok: false });
     });
   });

--- a/tests/unit/dashboard/fetchClient.test.ts
+++ b/tests/unit/dashboard/fetchClient.test.ts
@@ -1,0 +1,37 @@
+import { apiFetch, ApiError } from '../../../dashboard/lib/fetchClient'
+
+describe('apiFetch', () => {
+  const globalAny: any = global
+
+  beforeEach(() => {
+    jest.useFakeTimers()
+  })
+
+  afterEach(() => {
+    jest.useRealTimers()
+    delete globalAny.fetch
+  })
+
+  test('parses json success', async () => {
+    globalAny.fetch = jest.fn(() => Promise.resolve({ ok: true, text: async () => JSON.stringify({ a: 1 }) }))
+    const v = await apiFetch('/dashboard/api/summary')
+    expect(v.a).toBe(1)
+  })
+
+  test('throws ApiError for non-ok', async () => {
+    globalAny.fetch = jest.fn(() => Promise.resolve({ ok: false, status: 400, statusText: 'Bad', json: async () => ({ error: 'x' }), text: async () => '' }))
+    await expect(apiFetch('/dashboard/api/bad')).rejects.toBeInstanceOf(ApiError)
+  })
+
+  test('throws timeout', async () => {
+    // Mock fetch that resolves after a long delay
+    let resolver: any
+    globalAny.fetch = jest.fn(() => new Promise((resolve) => { resolver = resolve }))
+    const p = apiFetch('/dashboard/api/timeout', {}, 10)
+    // fast-forward timers to trigger abort
+    jest.advanceTimersByTime(50)
+    // now resolve the underlying fetch to ensure no unhandled promise
+    resolver({ ok: true, text: async () => '{}' })
+    await expect(p).rejects.toBeInstanceOf(ApiError)
+  })
+})

--- a/tests/unit/dashboard/operations.api.test.ts
+++ b/tests/unit/dashboard/operations.api.test.ts
@@ -1,0 +1,29 @@
+import optimizeHandler from '../../../dashboard/pages/api/optimize'
+import rollbackHandler from '../../../dashboard/pages/api/rollback'
+import * as guard from '../../../dashboard/lib/requireAdmin'
+
+const mockReq = () => ({ method: 'POST' } as any)
+const mockRes = () => {
+  const r: any = {}
+  r.status = jest.fn(() => r)
+  r.json = jest.fn(() => r)
+  return r
+}
+
+describe('operations APIs', () => {
+  beforeAll(() => {
+    jest.spyOn(guard as any, 'requireAdmin').mockResolvedValue({ ok: true, user: { id: 'test' } })
+  })
+
+  test('optimize returns queued job', async () => {
+    const res = mockRes()
+    await optimizeHandler(mockReq(), res)
+    expect(res.status).toHaveBeenCalledWith(200)
+  })
+
+  test('rollback returns queued job', async () => {
+    const res = mockRes()
+    await rollbackHandler(mockReq(), res)
+    expect(res.status).toHaveBeenCalledWith(200)
+  })
+})

--- a/tests/unit/dashboard/settings.api.test.ts
+++ b/tests/unit/dashboard/settings.api.test.ts
@@ -1,0 +1,42 @@
+import handler from '../../../dashboard/pages/api/settings'
+import * as guard from '../../../dashboard/lib/requireAdmin'
+import * as repo from '../../../src/lib/db/repository'
+
+describe('dashboard settings API', () => {
+  const mockReq = (method = 'GET', body?: any) => ({ method, body, query: {} } as any)
+  const mockRes = () => {
+    const res: any = {}
+    res.status = jest.fn(() => res)
+    res.json = jest.fn(() => res)
+    res.end = jest.fn(() => res)
+    res.setHeader = jest.fn()
+    return res
+  }
+
+  beforeAll(() => {
+    jest.spyOn(guard as any, 'requireAdmin').mockResolvedValue({ ok: true, user: { id: 'test' } })
+  })
+
+  beforeEach(() => {
+    jest.resetAllMocks()
+    jest.spyOn(guard as any, 'requireAdmin').mockResolvedValue({ ok: true, user: { id: 'test' } })
+    jest.spyOn(repo as any, 'upsertConfig').mockResolvedValue([{ key: 'dashboard:settings', value: {} }])
+  })
+
+  test('POST saves config', async () => {
+    const req = mockReq('POST', { enableAvif: true })
+    const res = mockRes()
+    await handler(req, res)
+    expect(res.status).toHaveBeenCalledWith(200)
+    expect(res.json).toHaveBeenCalledWith({ ok: true })
+  })
+
+  test('POST invalid payload returns 400 and does not upsert', async () => {
+    const spy = jest.spyOn(repo as any, 'upsertConfig')
+    const req = mockReq('POST', { enableAvif: 'not-a-bool' })
+    const res = mockRes()
+    await handler(req, res)
+    expect(res.status).toHaveBeenCalledWith(400)
+    expect(spy).not.toHaveBeenCalled()
+  })
+})


### PR DESCRIPTION
Adds a resilient client fetch helper with timeout and a consistent ApiError.
Adds a minimal in-memory enqueue helper and wires optimize / rollback dashboard API endpoints to enqueue jobs and return a jobId.
Rewires dashboard client wrappers to use the new apiFetch.
Adds unit tests for the fetch helper and updates tests that assumed old API paths